### PR TITLE
Fix not outputting to correct directory

### DIFF
--- a/EasyXnb/GeneratorGame.cs
+++ b/EasyXnb/GeneratorGame.cs
@@ -308,7 +308,7 @@ namespace DynamicFontGenerator
 				}
 				else
 				{
-					using (FileStream fileStream = new FileStream(text, FileMode.Create))
+					using (FileStream fileStream = new FileStream(outputDirectorySetting + "\\" + text, FileMode.Create))
 					{
 						_compileMethodInfo.Invoke(_contentCompiler, new object[7]
 						{
@@ -350,7 +350,7 @@ namespace DynamicFontGenerator
 				TextureContent textureContent = _textureProcessor.Process(input, _dfgContext);
 				Console.WriteLine(".Done!");
 				Console.Write("Start compiling texture content file: {0}", text);
-				using (FileStream fileStream = new FileStream(text, FileMode.Create))
+				using (FileStream fileStream = new FileStream(outputDirectorySetting + "\\" + text, FileMode.Create))
 				{
 					_compileMethodInfo.Invoke(_contentCompiler, new object[7]
 					{
@@ -454,7 +454,7 @@ namespace DynamicFontGenerator
 
                 Console.WriteLine(".Done!");
 				Console.Write("Start compiling model content file: {0}", outputFile);
-				using (FileStream fileStream = new FileStream(outputFile, FileMode.Create))
+				using (FileStream fileStream = new FileStream(outputDirectorySetting + "\\" + outputFile, FileMode.Create))
 				{
 					_compileMethodInfo.Invoke(_contentCompiler, new object[7]
 					{
@@ -496,7 +496,7 @@ namespace DynamicFontGenerator
 				CompiledEffectContent compiledEffectContent = _effectProcessor.Process(input, _dfgContext);
 				Console.WriteLine(".Done!");
 				Console.Write("Start compiling font content file: {0}", text);
-				using (FileStream fileStream = new FileStream(text, FileMode.Create))
+				using (FileStream fileStream = new FileStream(outputDirectorySetting + "\\" + text, FileMode.Create))
 				{
 					_compileMethodInfo.Invoke(_contentCompiler, new object[7]
 					{


### PR DESCRIPTION
the `FileStream`s used to output compiled content were missing the output directory in their pathing
```c#
using (FileStream fileStream = new FileStream(text, FileMode.Create))
{
```
becomes
```c#
using (FileStream fileStream = new FileStream(outputDirectorySetting + "\\" + text, FileMode.Create))
{
```
with this change it appears everything Is outputting to the correct directory now

fxc output notably did not suffer this issue because of this pathing
```c#
if (outputEffectBytecode)
{
	byte[] bytecode = compiledEffectContent.GetEffectCode();
	File.WriteAllBytes(outputDirectorySetting + "\\" + text, bytecode);
}
```