### PR TITLE
Fixed certain cultures crashing the app

### DIFF
--- a/EasyXnb/GeneratorGame.cs
+++ b/EasyXnb/GeneratorGame.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
 using Microsoft.Xna.Framework.Graphics;
 using System.Configuration;
 using System.Collections.Specialized;
+using System.Globalization;
 
 //untested:
 //texture loading in-game
@@ -126,7 +127,7 @@ namespace DynamicFontGenerator
 			closeImmediatelySetting = bool.Parse(ConfigurationManager.AppSettings.Get("CloseImmediately"));
 			waitForInputOnErrorSetting = bool.Parse(ConfigurationManager.AppSettings.Get("WaitForInputOnError"));
 
-            modelScale = float.Parse(ConfigurationManager.AppSettings.Get("ModelScale"));
+            modelScale = float.Parse(ConfigurationManager.AppSettings.Get("ModelScale"), CultureInfo.InvariantCulture);
 			modelSwapWindingOrder = bool.Parse(ConfigurationManager.AppSettings.Get("ModelSwapWindingOrder"));
 			modelGenerateTangentFrames = bool.Parse(ConfigurationManager.AppSettings.Get("ModelGenerateTangentFrames"));
 


### PR DESCRIPTION
When parsing floats, certain cultures use a comma to denote the beginning of decimals. When using float.Parse with one of these cultures, it will throw an exception if a period is used as the separator then.