### PR TITLE
Fixed foreground color leaking after finishing

### DIFF
--- a/EasyXnb/GeneratorGame.cs
+++ b/EasyXnb/GeneratorGame.cs
@@ -262,8 +262,11 @@ namespace DynamicFontGenerator
 
             if (!exceptionCaught || !waitForInputOnErrorSetting)
             {
+				ConsoleColor originalColor = Console.ForegroundColor;
 				Console.ForegroundColor = ConsoleColor.Green;
 				Console.WriteLine("Done! (Closing in 10 seconds)");
+				Console.ForegroundColor = originalColor;
+				
 				if (!closeImmediatelySetting)
 				{
 					Thread.Sleep(10000);


### PR DESCRIPTION
Very minor fix to address the fact that the console color gets set to green but never undoes it after the app finishes.
If more instances of foreground color changes are done, I would probably also implement an IDisposable ForegroundColorScope or something along those lines in order to automatically handle returning to previous colors.